### PR TITLE
Fix is_binary_data? was removed in 1.9. Add binary_data? utility function

### DIFF
--- a/lib/cassandra-cql/statement.rb
+++ b/lib/cassandra-cql/statement.rb
@@ -87,7 +87,7 @@ module CassandraCQL
         obj.to_guid
       # There are corner cases where this is an invalid assumption but they are extremely rare.
       # The alternative is to make the user pack the data on their own .. let's not do that until we have to
-      elsif obj.kind_of?(String) and obj.is_binary_data?
+      elsif obj.kind_of?(String) and Utility.binary_data?(obj)
         escape(obj.unpack('H*')[0])
       else
         escape(obj.to_s)

--- a/lib/cassandra-cql/utility.rb
+++ b/lib/cassandra-cql/utility.rb
@@ -9,5 +9,9 @@ module CassandraCQL
     def self.decompress(source)
       Zlib::Inflate.inflate(source)
     end
+
+    def self.binary_data?(string)
+      ( string.count( "^ -~", "^\r\n" ).fdiv(string.size) > 0.3 || string.index( "\x00" ) ) unless string.empty?
+    end
   end
 end

--- a/spec/utility_spec.rb
+++ b/spec/utility_spec.rb
@@ -5,7 +5,7 @@ describe "compress" do
   it "should return some valid gzipped stuff" do
     stuff = "This is some stuff"
     bytes = Utility.compress(stuff)
-    bytes.is_binary_data?.should be_true
+    Utility.binary_data?(bytes).should be_true
     Utility.decompress(bytes).should eq(stuff)
   end
 end


### PR DESCRIPTION
Fix is_binary_data? was removed in 1.9. Add binary_data? utility function.
