### PR TITLE
Fixed crash in row.column_names.

### DIFF
--- a/lib/cassandra-cql/row.rb
+++ b/lib/cassandra-cql/row.rb
@@ -14,7 +14,13 @@ module CassandraCQL
     end
 
     def column_names
-      @names ||= @row.columns.map { |column| ColumnFamily.cast(column.name, @column_family.comparator_type) }
+      @names ||= @row.columns.map do |column|
+        if column.name == @column_family.key_alias
+          column.name
+        else
+          ColumnFamily.cast(column.name, @column_family.comparator_type)
+        end
+      end
     end
   
     def column_values

--- a/spec/fixtures/result_for_timeuuid.yaml
+++ b/spec/fixtures/result_for_timeuuid.yaml
@@ -1,0 +1,17 @@
+--- !ruby/object:CassandraThrift::CqlResult
+rows:
+- !ruby/object:CassandraThrift::CqlRow
+  columns:
+  - !ruby/object:CassandraThrift::Column
+    name: KEY
+    timestamp: -1
+    value: incinerators-councils
+  - !ruby/object:CassandraThrift::Column
+    name: !binary |
+      tAeA9KciEeCFVRy7npxYoA==
+
+    timestamp: 1313700445148
+    value: Olympiad-bayonet
+  key: incinerators-councils
+
+type: 1

--- a/spec/row_spec.rb
+++ b/spec/row_spec.rb
@@ -7,6 +7,10 @@ describe "basic methods" do
   let(:cql_result_row) { yaml_fixture(:result_for_standard_with_validations).rows[0] }
   let(:row) { Row.new(cql_result_row, column_family) }
 
+  let(:cf_time_uuid_comp) { ColumnFamily.new(yaml_fixture(:standard_column_family)) }
+  let(:cql_result_time_uuid_row) { yaml_fixture(:result_for_timeuuid).rows[0] }
+  let(:row_time_uuid) { Row.new(cql_result_time_uuid_row, cf_time_uuid_comp) }
+
   context "initialize" do
     it "should set row and column_family" do
       row.row.should eq(cql_result_row)
@@ -46,6 +50,10 @@ describe "basic methods" do
 
     it "should return a String for default_column" do
       row['default_column'].should be_kind_of(String)
+    end
+
+    it "should not crash when getting the row key name from column names" do
+      lambda { row_time_uuid.column_names }.should_not raise_error
     end
   end
   


### PR DESCRIPTION
A wildcard query on a column family with a comparator_type of TimeUUID
would crash trying to cast the row key to a SimpleUUID.
