### PR TITLE
Make sure nil values get cast as nil

### DIFF
--- a/lib/cassandra-cql/schema.rb
+++ b/lib/cassandra-cql/schema.rb
@@ -60,6 +60,8 @@ module CassandraCQL
     end
 
     def self.cast(value, type)
+      return nil if value.nil?
+
       case type
       when "org.apache.cassandra.db.marshal.TimeUUIDType"
         UUID.to_time(value)

--- a/spec/column_family_spec.rb
+++ b/spec/column_family_spec.rb
@@ -87,6 +87,13 @@ describe "ColumnFamily class" do
       obj = Object.new
       ColumnFamily.cast(obj, "org.apache.cassandra.db.marshal.BytesType").object_id.should eq(obj.object_id)
     end
+
+    it "should return nil for all types of nil" do
+      %w(TimeUUIDType UUIDType LongType IntegerType
+        UTF8Type AsciiType CounterColumnType).each do |type|
+        ColumnFamily.cast(nil, "org.apache.cassandra.db.marshal.#{type}").should eq(nil)
+      end
+    end
   end
 
   context "validations classes" do


### PR DESCRIPTION
Before this patch, different types came out with different behaviors.  In some instances, it would throw a MethodMissing, in others, it would return a blank string instead of nil.

This patch makes sure that nil is nil.
