### PR TITLE
Problems when empty strings return for integers

### DIFF
--- a/lib/cassandra-cql/types/abstract_type.rb
+++ b/lib/cassandra-cql/types/abstract_type.rb
@@ -24,6 +24,9 @@ module CassandraCQL
       private
       
       def self.bytes_to_int(bytes)
+      	#An empty string as a value for an integer 
+      	#--> somebody didn't set a value
+      	return nil if bytes.empty?
         int = 0
         values = bytes.unpack('C*')
         values.each {|v| int = int << 8; int += v; }
@@ -34,6 +37,9 @@ module CassandraCQL
       end
 
       def self.bytes_to_long(bytes)
+		#An empty string as a value for an long 
+      	#--> somebody didn't set a value
+      	return nil if bytes.empty?
         ints = bytes.unpack("NN")
         val = (ints[0] << 32) + ints[1]
         if val & 2**63 == 2**63


### PR DESCRIPTION
We already [a fix](https://github.com/kreynolds/cassandra-cql/commit/a2740cd3a7f3fbf2c650e2e9c5bb8ad66ec5d48c) concerning the handling of nil as a row value, but there seem to still be some edge cases.  

My current problem:  
I insert a hash with data using cassandra-cql like this

```
db.execute("INSERT INTO domains (domain, rank) VALUES (?, ?)", item[:domain], item[:rank]")
```

When item[:rank] is nil, it will be inserted as an empty string.
When this empty string comes back for the integer column, we crash. This pull requests fixes the crash, I'm still looking into how we can keep nil from being inserted as an empty string. So far I haven't found any documentation on how nil/NULL is represented in a CQL insert query.
