### PR TITLE
More rubyish Result class

### DIFF
--- a/lib/cassandra-cql/result.rb
+++ b/lib/cassandra-cql/result.rb
@@ -63,6 +63,9 @@ module CassandraCQL
       @result.rows.size
     end
 
+    alias_method :size, :rows
+    alias_method :length, :rows
+
     def cursor=(cursor)
       @cursor = cursor.to_i
     rescue Exception => e

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -57,7 +57,18 @@ describe "row results" do
   it "should have two rows" do
     @result.rows.should eq(2)
   end
-  
+
+  it "should know size of rows" do
+    @result.size.should eq(2)
+  end
+
+  it "should know count of rows" do
+    @result.count.should eq(2)
+  end
+
+  it "should know length of rows" do
+    @result.length.should eq(2)
+  end
 
   describe "#each" do
     it "yields each row as a hash" do


### PR DESCRIPTION
This adds #each, #size, #length, #count, and makes result Enumerable.

One note: I am running specs against cass 1.1. In order to get the specs to pass, I had to make sure that the keyspace check in setup_cassandra_connection in spec_helper was case insensitive. I did not include that in this pull request, but I certainly can if you are ok with it.
