### PR TITLE
Support SimpleUUID::UUID instances as well.

### DIFF
--- a/lib/cassandra-cql/statement.rb
+++ b/lib/cassandra-cql/statement.rb
@@ -90,7 +90,7 @@ module CassandraCQL
         obj.strftime('%Y-%m-%d')
       elsif obj.kind_of?(Time)
         (obj.to_f * 1000).to_i
-      elsif obj.kind_of?(UUID)
+      elsif obj.kind_of?(SimpleUUID::UUID)
         obj.to_guid
       # There are corner cases where this is an invalid assumption but they are extremely rare.
       # The alternative is to make the user pack the data on their own .. let's not do that until we have to

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -130,6 +130,14 @@ describe "cast_to_cql" do
     end
   end
 
+  context "with a SimpleUUID::UUID object" do
+    it "should return the guid" do
+      uuid = SimpleUUID::UUID.new
+      guid = Statement.cast_to_cql(uuid)
+      guid.should eq(uuid.to_guid)
+    end
+  end
+
   context "with a String without quotes" do
     it "should return a copy of itself" do
       str = "This is a string"


### PR DESCRIPTION
Since CassandraCQL::UUID just inherits from it, we might as well support the whole family. I've already had a few times where I tried to insert SimpleUUID::UUID's and it didn't work, which confused me.
