### PR TITLE
Switch to lowercase keyspace name

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,10 +23,10 @@ end
 
 def setup_cassandra_connection
   connection = CassandraCQL::Database.new(["127.0.0.1:9160"], {}, :retries => 5, :timeout => 1)
-  if !connection.keyspaces.map(&:name).include?("CassandraCQLTestKeyspace")
-    connection.execute("CREATE KEYSPACE CassandraCQLTestKeyspace WITH strategy_class='org.apache.cassandra.locator.SimpleStrategy' AND strategy_options:replication_factor=1")
+  if !connection.keyspaces.map(&:name).include?("cassandra_cql_test")
+    connection.execute("CREATE KEYSPACE cassandra_cql_test WITH strategy_class='org.apache.cassandra.locator.SimpleStrategy' AND strategy_options:replication_factor=1")
   end
-  connection.execute("USE CassandraCQLTestKeyspace")
+  connection.execute("USE cassandra_cql_test")
 
   connection
 end


### PR DESCRIPTION
Must be my version of cassandra (1.1.5), but I could not get the tests to run without changing to a lowercase keyspace name.

I tried just doing the include check with lowercase, but cassandra really did not like the switching of case in various places. This seems to work best from what I can tell.

Decided rather than just ask you about it, I would start the discussion with a version that seems to fix the problem for me and get your thoughts.

If you want, I can send you the output I get.
