### PR TITLE
Login before using a keyspace

### DIFF
--- a/lib/cassandra-cql/database.rb
+++ b/lib/cassandra-cql/database.rb
@@ -46,11 +46,16 @@ module CassandraCQL
 
     def connect!
       @connection = ThriftClient.new(CassandraCQL::Thrift::Client, @servers, @thrift_client_options)
+
+      if @options[:username] and @options[:password]
+        login!(@options[:username], @options[:password])
+      end
+
       obj = self
       @connection.add_callback(:post_connect) do
         @connection.set_cql_version(@cql_version) if @cql_version
-        execute("USE #{@keyspace}")
         @connection.login(@auth_request) if @auth_request
+        execute("USE #{@keyspace}")
       end
     end
 


### PR DESCRIPTION
Cassandra 1.2 will throw an error if authentication has been enabled, and the client tries to use a keyspace before login.

Since cassandra-cql always tries to use a keyspace (system by default) during the client initialization, in case of authentication the login! method must be called before using a keyspace.
