### PR TITLE
default to cassandra 1.2, and use cql3 transport methods automatically

### DIFF
--- a/lib/cassandra-cql.rb
+++ b/lib/cassandra-cql.rb
@@ -16,7 +16,7 @@ limitations under the License.
 
 module CassandraCQL; end;
 unless CassandraCQL.respond_to?(:CASSANDRA_VERSION)
-  require "cassandra-cql/1.1"
+  require "cassandra-cql/1.2"
 end
 
 here = File.expand_path(File.dirname(__FILE__))

--- a/lib/cassandra-cql/statement.rb
+++ b/lib/cassandra-cql/statement.rb
@@ -74,17 +74,16 @@ module CassandraCQL
         obj.map { |member| quote(member, use_cql3) }.join(",")
       elsif obj.kind_of?(String)
         "'" + obj + "'"
-      elsif obj.kind_of?(BigDecimal) and (!use_cql3 or CASSANDRA_VERSION.to_f < 1.2)
+      elsif obj.kind_of?(BigDecimal) and !use_cql3
         "'" + obj.to_s + "'"
       elsif obj.kind_of?(Numeric)
         obj.to_s
       elsif obj.kind_of?(SimpleUUID::UUID)
         obj.to_guid
-      #elsif obj.kind_of?(TrueClass) or obj.kind_of?(FalseClass) and use_cql3 and CASSANDRA_VERSION.to_f == 1.2
-      #  obj.to_s
-      elsif obj.kind_of?(TrueClass) or obj.kind_of?(FalseClass)
-        #"'" + obj.to_s + "'"
+      elsif obj.kind_of?(TrueClass) or obj.kind_of?(FalseClass) and use_cql3
         obj.to_s
+      elsif obj.kind_of?(TrueClass) or obj.kind_of?(FalseClass)
+        "'" + obj.to_s + "'"
       else
         raise Error::UnescapableObject, "Unable to escape object of class #{obj.class}"
       end

--- a/lib/cassandra-cql/types/date_type.rb
+++ b/lib/cassandra-cql/types/date_type.rb
@@ -23,5 +23,7 @@ module CassandraCQL
         raise Error::CastException.new("Unable to convert bytes to Date", value)
       end
     end
+
+    TimestampType = DateType
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ require 'rspec'
 
 CASSANDRA_VERSION = ENV['CASSANDRA_VERSION'] || '1.1' unless defined?(CASSANDRA_VERSION)
 CQL_VERSION = ENV['CQL_VERSION'] || '2.0.0'
-USE_CQL3 = CQL_VERSION.split('.').first.to_i == 3
+USE_CQL3 = CQL_VERSION.split('.').first.to_i == 3 && CASSANDRA_VERSION >= '1.2'
 
 require "cassandra-cql/#{CASSANDRA_VERSION}"
 

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -107,9 +107,16 @@ describe "quote" do
     end  
   end
   context "with a boolean" do
-    it "should not add quotes" do
-      Statement.quote(true, USE_CQL3).should eq("true")
-      Statement.quote(false, USE_CQL3).should eq("false")
+    if USE_CQL3
+      it "should not add quotes" do
+        Statement.quote(true, USE_CQL3).should eq("true")
+        Statement.quote(false, USE_CQL3).should eq("false")
+      end
+    else
+      it "should add quotes" do
+        Statement.quote(true, USE_CQL3).should eq("'true'")
+        Statement.quote(false, USE_CQL3).should eq("'false'")
+      end
     end
   end
 


### PR DESCRIPTION
also, don't execute USE in initialize; the after connect callback will
do that; it would start a cql query before it knew which version
to speak

third, fix quoting for cassandra 1.1

finally, DateType was renamed to TimestampType, so alias the
cast class
