### PR TITLE
Cast Hash as Collection Map

### DIFF
--- a/lib/cassandra-cql/statement.rb
+++ b/lib/cassandra-cql/statement.rb
@@ -72,6 +72,8 @@ module CassandraCQL
     def self.quote(obj, use_cql3=false)
       if obj.kind_of?(Array)
         obj.map { |member| quote(member, use_cql3) }.join(",")
+      elsif obj.kind_of?(String) and obj.match /^\{.*\}$/
+        obj
       elsif obj.kind_of?(String)
         "'" + obj + "'"
       elsif obj.kind_of?(BigDecimal) and !use_cql3
@@ -89,9 +91,11 @@ module CassandraCQL
       end
     end
 
-    def self.cast_to_cql(obj)
+    def self.cast_to_cql(obj, use_cql3=false)
       if obj.kind_of?(Array)
         obj.map { |member| cast_to_cql(member) }
+      elsif obj.kind_of?(Hash)
+        "{"+obj.map{ |key,val| "#{quote(cast_to_cql(key), use_cql3)}:#{quote(cast_to_cql(val), use_cql3)}" }.join(',')+"}"
       elsif obj.kind_of?(Numeric)
         obj
       elsif obj.kind_of?(Date)
@@ -110,7 +114,7 @@ module CassandraCQL
         RUBY_VERSION >= "1.9" ? escape(obj.to_s.dup.force_encoding('ASCII-8BIT')) : escape(obj.to_s.dup)
       end
     end
-  
+
     def self.sanitize(statement, bind_vars=[], use_cql3=false)
       # If there are no bind variables, return the statement unaltered
       return statement if bind_vars.empty?
@@ -119,9 +123,9 @@ module CassandraCQL
       expected_bind_vars = statement.count("?")
 
       raise Error::InvalidBindVariable, "Wrong number of bound variables (statement expected #{expected_bind_vars}, was #{bind_vars.size})" if expected_bind_vars != bind_vars.size
-    
+
       statement.gsub(/\?/) {
-        quote(cast_to_cql(bind_vars.shift), use_cql3)
+        quote(cast_to_cql(bind_vars.shift, use_cql3), use_cql3)
       }
     end
   end

--- a/spec/row_spec.rb
+++ b/spec/row_spec.rb
@@ -25,14 +25,14 @@ describe "basic methods" do
         @row.column_values.size.should eq(@row.column_names.size)
       end
     end
-      
+
     context "columns" do
       it "should equal the number of columns" do
         @row.column_names.size.should eq(@row.column_values.size)
         @row.columns.should eq(@row.column_names.size)
       end
     end
-    
+
     context "checking casting" do
       it "should return column_values for to_a" do
         @row.to_a.should eq(@row.column_values)
@@ -83,7 +83,8 @@ describe "basic methods" do
           key text PRIMARY KEY,
           mylist LIST <int>,
           myset SET <varchar>,
-          mymap MAP <uuid,timestamp>
+          mymap MAP <uuid,timestamp>,
+          myflattenmap MAP <uuid,timestamp>
         )
       CQL
 
@@ -93,8 +94,8 @@ describe "basic methods" do
       }
 
       @connection.execute(
-        "INSERT INTO collections (key, mylist, myset, mymap) VALUES (?, [?], {?}, {?:?,?:?})",
-        'test', [1, 2, 3], ['some', 'set'], *@map.to_a.flatten)
+        "INSERT INTO collections (key, mylist, myset, mymap, myflattenmap) VALUES (?, [?], {?}, ?, {?:?,?:?})",
+        'test', [1, 2, 3], ['some', 'set'], @map, *@map.to_a.flatten)
 
       @row = @connection.execute("SELECT * FROM collections WHERE key=?", "test").fetch
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,8 +10,8 @@ Bundler.setup(:default, :test)
 require 'yaml'
 require 'rspec'
 
-CASSANDRA_VERSION = ENV['CASSANDRA_VERSION'] || '1.1' unless defined?(CASSANDRA_VERSION)
-CQL_VERSION = ENV['CQL_VERSION'] || '2.0.0'
+CASSANDRA_VERSION = ENV['CASSANDRA_VERSION'] || '1.2' unless defined?(CASSANDRA_VERSION)
+CQL_VERSION = ENV['CQL_VERSION'] || '3.0.0'
 USE_CQL3 = CQL_VERSION.split('.').first.to_i == 3 && CASSANDRA_VERSION >= '1.2'
 
 require "cassandra-cql/#{CASSANDRA_VERSION}"


### PR DESCRIPTION
- Allow passing a Hash as a value for a Map column.
- Set defaults in spec_helper to: CASSANDRA_VERSION=1.2 and CQL_VERSION=3.0.0
