### PR TITLE
Being able to toggle constancy level during execute statement

### DIFF
--- a/lib/cassandra-cql/database.rb
+++ b/lib/cassandra-cql/database.rb
@@ -100,8 +100,12 @@ module CassandraCQL
       end
     end
 
-    def execute(statement, *bind_vars)
-      result = statement_class.new(self, statement).execute(bind_vars)
+    def execute(statement, consistency, *bind_vars)
+        # consistency can be either of the following options:
+        #  - CassandraCQL::Thrift::ConsistencyLevel::QUORUM
+        #  - CassandraCQL::Thrift::ConsistencyLevel::LOCAL_QUORUM
+        #  - CassandraCQL::Thrift::ConsistencyLevel::ONE
+      result = statement_class.new(self, statement, consistency).execute(bind_vars)
       if block_given?
         yield result
       else
@@ -113,10 +117,6 @@ module CassandraCQL
 
     def execute_cql_query(cql, compression=CassandraCQL::Thrift::Compression::NONE, consistency=CassandraCQL::Thrift::ConsistencyLevel::QUORUM)
       if use_cql3?
-        # consistency can be either of the following options:
-        #  - CassandraCQL::Thrift::ConsistencyLevel::QUORUM
-        #  - CassandraCQL::Thrift::ConsistencyLevel::LOCAL_QUORUM
-        #  - CassandraCQL::Thrift::ConsistencyLevel::ONE
         @connection.execute_cql3_query(cql, compression, consistency) 
       else
         @connection.execute_cql_query(cql, compression)


### PR DESCRIPTION
Would like to have flexibility to configure the consistency level during CQL execute.

For instance, in our use case we have the consistency level set at LOCAL_QUORUM for writes, and ONE for reads.If a user doesn't bother with consistency levels, the default option is QUORUM (which would be the setting that would occur before this change).
