### PR TITLE
Being able to toggle constancy level during execute statement

### DIFF
--- a/lib/cassandra-cql/statement.rb
+++ b/lib/cassandra-cql/statement.rb
@@ -36,12 +36,17 @@ module CassandraCQL
       @statement = statement
     end
 
-    def execute(bind_vars=[], consistency, options={})
+    def execute(bind_vars=[], options={})
       sanitized_query = self.class.sanitize(@statement, bind_vars, @handle.use_cql3?)
       compression_type = CassandraCQL::Thrift::Compression::NONE
       if options[:compression]
         compression_type = CassandraCQL::Thrift::Compression::GZIP
         sanitized_query = Utility.compress(sanitized_query)
+      end
+
+      consistency = CassandraCQL::Thrift::ConsistencyLevel::QUORUM
+      if options[:consistency]
+        consistency = options[:consistency]
       end
 
       res = Result.new(@handle.execute_cql_query(sanitized_query, compression_type, consistency))


### PR DESCRIPTION
Would like to have flexibility to configure the consistency level during CQL execute.

For instance, in our use case we have the consistency level set at LOCAL_QUORUM for writes, and ONE for reads.If a user doesn't bother with consistency levels, the default option is QUORUM (which would be the setting that would occur before this change)
